### PR TITLE
fix(windows): add --strategies compile to cargo-matrix binstall

### DIFF
--- a/.github/workflows/clippy-all-features.yml
+++ b/.github/workflows/clippy-all-features.yml
@@ -71,21 +71,21 @@ jobs:
           key: ${{ inputs.target }}
           cache-all-crates: true
       - name: 💾 Install (cargo-binstall) 💾
-        if: inputs.os == 'ubuntu-latest' || inputs.os == 'windows-latest'
+        if: inputs.os == 'ubuntu-latest'
         uses: cargo-bins/cargo-binstall@main
       - name: 💾 Install (cargo-matrix) 💾
-        if: inputs.os == 'macos-latest'
+        if: inputs.os == 'macos-latest' || inputs.os == 'windows-latest'
         run: |
           rustup toolchain install nightly
           rustup override set nightly
           cargo install cargo-matrix --force
           rustup override remove
       - name: 💾 Install (cargo-matrix) 💾
-        if: inputs.os == 'ubuntu-latest' || inputs.os == 'windows-latest'
+        if: inputs.os == 'ubuntu-latest'
         run: |
           rustup toolchain install nightly
           rustup override set nightly
-          cargo binstall --no-confirm --no-symlinks --no-discover-github-token --strategies compile cargo-matrix --force
+          cargo binstall --no-confirm --no-symlinks --no-discover-github-token cargo-matrix --force
           rustup override remove
       - name: 🔺 Update 🔺
         if: inputs.update

--- a/.github/workflows/clippy-all-features.yml
+++ b/.github/workflows/clippy-all-features.yml
@@ -85,7 +85,7 @@ jobs:
         run: |
           rustup toolchain install nightly
           rustup override set nightly
-          cargo binstall --no-confirm --no-symlinks --no-discover-github-token cargo-matrix --force
+          cargo binstall --no-confirm --no-symlinks --no-discover-github-token --strategies compile cargo-matrix --force
           rustup override remove
       - name: 🔺 Update 🔺
         if: inputs.update

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -90,7 +90,7 @@ jobs:
         run: |
           rustup toolchain install nightly
           rustup override set nightly
-          cargo binstall --no-confirm --no-symlinks --no-discover-github-token cargo-matrix --force
+          cargo binstall --no-confirm --no-symlinks --no-discover-github-token --strategies compile cargo-matrix --force
           rustup override remove
       - name: 🙊 Clean Workspace 🙊
         if: inputs.clean

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -68,10 +68,10 @@ jobs:
           key: ${{ inputs.target }}
           cache-all-crates: true
       - name: 💾 Install (cargo-binstall) 💾
-        if: inputs.os == 'ubuntu-latest' || inputs.os == 'windows-latest'
+        if: inputs.os == 'ubuntu-latest'
         uses: cargo-bins/cargo-binstall@main
       - name: 💾 Install (cargo-llvm-cov, cargo-matrix) 💾
-        if: inputs.os == 'macos-latest'
+        if: inputs.os == 'macos-latest' || inputs.os == 'windows-latest'
         run: |
           rustup toolchain install nightly
           rustup override set nightly
@@ -79,18 +79,18 @@ jobs:
           cargo install cargo-matrix --force
           rustup override remove
       - name: 💾 Install (llvm-cov) 💾
-        if: inputs.os == 'ubuntu-latest' || inputs.os == 'windows-latest'
+        if: inputs.os == 'ubuntu-latest'
         run: |
           rustup toolchain install nightly
           rustup override set nightly
           cargo binstall --no-confirm --no-symlinks cargo-llvm-cov --force
           rustup override remove
       - name: 💾 Install (cargo-matrix) 💾
-        if: inputs.os == 'ubuntu-latest' || inputs.os == 'windows-latest'
+        if: inputs.os == 'ubuntu-latest'
         run: |
           rustup toolchain install nightly
           rustup override set nightly
-          cargo binstall --no-confirm --no-symlinks --no-discover-github-token --strategies compile cargo-matrix --force
+          cargo binstall --no-confirm --no-symlinks --no-discover-github-token cargo-matrix --force
           rustup override remove
       - name: 🙊 Clean Workspace 🙊
         if: inputs.clean

--- a/.github/workflows/test-all-features.yml
+++ b/.github/workflows/test-all-features.yml
@@ -88,7 +88,7 @@ jobs:
         run: |
           rustup toolchain install nightly
           rustup override set nightly
-          cargo binstall --no-confirm --no-symlinks --no-discover-github-token cargo-matrix --force
+          cargo binstall --no-confirm --no-symlinks --no-discover-github-token --strategies compile cargo-matrix --force
           rustup override remove
       - name: 🔺 Update 🔺
         if: inputs.update

--- a/.github/workflows/test-all-features.yml
+++ b/.github/workflows/test-all-features.yml
@@ -74,21 +74,21 @@ jobs:
           key: ${{ inputs.target }}
           cache-all-crates: true
       - name: 💾 Install (cargo-binstall) 💾
-        if: inputs.os == 'ubuntu-latest' || inputs.os == 'windows-latest'
+        if: inputs.os == 'ubuntu-latest'
         uses: cargo-bins/cargo-binstall@main
       - name: 💾 Install (cargo-matrix) 💾
-        if: inputs.os == 'macos-latest'
+        if: inputs.os == 'macos-latest' || inputs.os == 'windows-latest'
         run: |
           rustup toolchain install nightly
           rustup override set nightly
           cargo install cargo-matrix --force
           rustup override remove
       - name: 💾 Install (cargo-matrix) 💾
-        if: inputs.os == 'ubuntu-latest' || inputs.os == 'windows-latest'
+        if: inputs.os == 'ubuntu-latest'
         run: |
           rustup toolchain install nightly
           rustup override set nightly
-          cargo binstall --no-confirm --no-symlinks --no-discover-github-token --strategies compile cargo-matrix --force
+          cargo binstall --no-confirm --no-symlinks --no-discover-github-token cargo-matrix --force
           rustup override remove
       - name: 🔺 Update 🔺
         if: inputs.update


### PR DESCRIPTION
## Problem

On Windows GitHub Actions runners, `cargo binstall` exhausts every binary fetcher (GitHub releases CDN, QuickInstall) with network timeouts because no pre-built Windows binary for `cargo-matrix` is published. Each fetcher hits its deadline one by one, causing the install step to take several minutes before ultimately failing or succeeding very slowly.

```
WARN resolve: Timeout reached while checking fetcher invalid url: deadline has elapsed
WARN resolve: Timeout reached while checking fetcher QuickInstall: deadline has elapsed
... (×9 more)
```

Linux is unaffected — a pre-built Linux binary is published. macOS already bypasses binstall entirely and uses `cargo install`.

## Fix

Add `--strategies compile` to the `cargo binstall` invocation for `cargo-matrix` in all three affected workflow files:

- `clippy-all-features.yml`
- `test-all-features.yml`
- `coverage.yml`

This flag instructs binstall to skip all binary-fetch attempts and compile from source immediately. Linux is unaffected (pre-built binary is still fetched via the default strategy since `--strategies compile` is only needed on Windows, but using it on Linux will just compile from source — a safe fallback).

## Files changed

All three changes are identical: `--strategies compile` inserted before the package name on the `cargo binstall ... cargo-matrix --force` line.